### PR TITLE
Add support for reading float arrays

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,6 +1,6 @@
 use criterion::{Criterion, criterion_group, criterion_main};
-use eccodes::FallibleIterator;
 use eccodes::codes_file::{CodesFile, ProductKind};
+use eccodes::{FallibleIterator, KeyRead};
 use std::hint::black_box;
 use std::path::Path;
 
@@ -26,6 +26,14 @@ pub fn key_reading(c: &mut Criterion) {
 
     c.bench_function("double array reading", |b| {
         b.iter(|| msg.read_key_dynamic(black_box("values")).unwrap())
+    });
+
+    c.bench_function("static double array reading", |b| {
+        b.iter(|| -> Vec<f64> { msg.read_key(black_box("values")).unwrap() })
+    });
+
+    c.bench_function("static float array reading", |b| {
+        b.iter(|| -> Vec<f32> { msg.read_key(black_box("values")).unwrap() })
     });
 
     c.bench_function("string reading", |b| {

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,6 +1,6 @@
 use criterion::{Criterion, criterion_group, criterion_main};
-use eccodes::codes_file::{CodesFile, ProductKind};
 use eccodes::{FallibleIterator, KeyRead};
+use eccodes::codes_file::{CodesFile, ProductKind};
 use std::hint::black_box;
 use std::path::Path;
 

--- a/src/codes_message/read.rs
+++ b/src/codes_message/read.rs
@@ -4,8 +4,9 @@ use crate::{
     codes_message::CodesMessage,
     errors::CodesError,
     intermediate_bindings::{
-        NativeKeyType, codes_get_bytes, codes_get_double, codes_get_double_array, codes_get_long,
-        codes_get_long_array, codes_get_native_type, codes_get_size, codes_get_string,
+        NativeKeyType, codes_get_bytes, codes_get_double, codes_get_double_array,
+        codes_get_float_array, codes_get_long, codes_get_long_array, codes_get_native_type,
+        codes_get_size, codes_get_string,
     },
 };
 
@@ -25,7 +26,7 @@ pub trait KeyRead<T> {
     ///  let mut file = CodesFile::new_from_file("./data/iceland.grib", ProductKind::GRIB)?;
     ///  let message = file.ref_message_iter().next()?.context("no message")?;
     ///  let short_name: String = message.read_key("shortName")?;
-    ///  
+    ///
     ///  assert_eq!(short_name, "msl");
     ///  # Ok(())
     ///  # }
@@ -113,6 +114,13 @@ macro_rules! key_size_check {
 
 impl_key_read!(scalar, codes_get_long, NativeKeyType::Long, i64);
 impl_key_read!(scalar, codes_get_double, NativeKeyType::Double, f64);
+// Double-typed ecCodes arrays can be decoded directly into f32.
+impl_key_read!(
+    array,
+    codes_get_float_array,
+    NativeKeyType::Double,
+    Vec<f32>
+);
 impl_key_read!(array, codes_get_string, NativeKeyType::Str, String);
 impl_key_read!(array, codes_get_bytes, NativeKeyType::Bytes, Vec<u8>);
 impl_key_read!(array, codes_get_long_array, NativeKeyType::Long, Vec<i64>);
@@ -173,7 +181,7 @@ impl<P: Debug> CodesMessage<P> {
     ///  let message = file.ref_message_iter().next()?.context("no message")?;
     ///  let message_short_name = message.read_key_dynamic("shortName")?;
     ///  let expected_short_name = DynamicKeyType::Str("msl".to_string());
-    ///  
+    ///
     ///  assert_eq!(message_short_name, expected_short_name);
     ///  # Ok(())
     ///  # }

--- a/src/codes_message/read.rs
+++ b/src/codes_message/read.rs
@@ -26,7 +26,7 @@ pub trait KeyRead<T> {
     ///  let mut file = CodesFile::new_from_file("./data/iceland.grib", ProductKind::GRIB)?;
     ///  let message = file.ref_message_iter().next()?.context("no message")?;
     ///  let short_name: String = message.read_key("shortName")?;
-    ///
+    ///  
     ///  assert_eq!(short_name, "msl");
     ///  # Ok(())
     ///  # }
@@ -181,7 +181,7 @@ impl<P: Debug> CodesMessage<P> {
     ///  let message = file.ref_message_iter().next()?.context("no message")?;
     ///  let message_short_name = message.read_key_dynamic("shortName")?;
     ///  let expected_short_name = DynamicKeyType::Str("msl".to_string());
-    ///
+    ///  
     ///  assert_eq!(message_short_name, expected_short_name);
     ///  # Ok(())
     ///  # }

--- a/src/intermediate_bindings/codes_get.rs
+++ b/src/intermediate_bindings/codes_get.rs
@@ -95,6 +95,30 @@ pub unsafe fn codes_get_double_array(
     }
 }
 
+pub unsafe fn codes_get_float_array(
+    handle: *const codes_handle,
+    key: &str,
+) -> Result<Vec<f32>, CodesError> {
+    unsafe {
+        pointer_guard::non_null!(handle);
+
+        let mut key_size = codes_get_size(handle, key)?;
+        let key = CString::new(key).unwrap();
+
+        let mut key_values: Vec<f32> = vec![0.0; key_size];
+
+        let error_code = eccodes_sys::codes_get_float_array(
+            handle,
+            key.as_ptr(),
+            key_values.as_mut_ptr().cast(),
+            &raw mut key_size,
+        );
+        error_code_to_result(error_code)?;
+
+        Ok(key_values)
+    }
+}
+
 pub unsafe fn codes_get_long_array(
     handle: *const codes_handle,
     key: &str,
@@ -229,7 +253,7 @@ pub unsafe fn codes_get_message(
 
         debug_assert!(
             buffer_size == message_size,
-            "Buffer and message sizes ar not equal in codes_get_message! 
+            "Buffer and message sizes ar not equal in codes_get_message!
         Please report this panic on Github."
         );
 

--- a/src/intermediate_bindings/codes_get.rs
+++ b/src/intermediate_bindings/codes_get.rs
@@ -253,7 +253,7 @@ pub unsafe fn codes_get_message(
 
         debug_assert!(
             buffer_size == message_size,
-            "Buffer and message sizes ar not equal in codes_get_message!
+            "Buffer and message sizes ar not equal in codes_get_message! 
         Please report this panic on Github."
         );
 

--- a/src/intermediate_bindings/mod.rs
+++ b/src/intermediate_bindings/mod.rs
@@ -5,7 +5,7 @@
 //!These bindings convert Rust types to correct C types
 //!correctly represent data as pointers and utilize some other functions
 //!to make ecCodes usage safer and easier,
-//!but they are unsafe as they operate on raw `codes_handle`.  
+//!but they are unsafe as they operate on raw `codes_handle`.
 
 mod codes_get;
 mod codes_handle;
@@ -26,8 +26,8 @@ pub enum NativeKeyType {
 }
 
 pub use codes_get::{
-    codes_get_bytes, codes_get_double, codes_get_double_array, codes_get_long,
-    codes_get_long_array, codes_get_message, codes_get_native_type, codes_get_size,
+    codes_get_bytes, codes_get_double, codes_get_double_array, codes_get_float_array,
+    codes_get_long, codes_get_long_array, codes_get_message, codes_get_native_type, codes_get_size,
     codes_get_string,
 };
 pub use codes_handle::{codes_handle_clone, codes_handle_delete, codes_handle_new_from_file};

--- a/src/intermediate_bindings/mod.rs
+++ b/src/intermediate_bindings/mod.rs
@@ -5,7 +5,7 @@
 //!These bindings convert Rust types to correct C types
 //!correctly represent data as pointers and utilize some other functions
 //!to make ecCodes usage safer and easier,
-//!but they are unsafe as they operate on raw `codes_handle`.
+//!but they are unsafe as they operate on raw `codes_handle`.  
 
 mod codes_get;
 mod codes_handle;


### PR DESCRIPTION
Adds support for decoding floating point arrays as `Vec<f32>` using `codes_get_float_array`. This is useful when the values are needed as `Vec<f32>` downstream since it avoids reading as `Vec<f64>` and converting manually afterward.

I added 2 benchmarks, which show that it is slightly faster, although the main improvement should be in downstream application code.
```
double array reading    time:   [1.5537 µs 1.5576 µs 1.5642 µs]  // preexisting

static double array reading
                        time:   [1.5308 µs 1.5359 µs 1.5436 µs]

static float array reading
                        time:   [1.4714 µs 1.4723 µs 1.4734 µs]
```

I tried to do everything as close to the existing implementations as possible. I am happy to adjust anything if you prefer a different API shape.